### PR TITLE
fix: mark the `ZodDate` as `string` type in the OpenAPI schema

### DIFF
--- a/packages/nestjs-zod/src/openapi/zod-to-openapi.test.ts
+++ b/packages/nestjs-zod/src/openapi/zod-to-openapi.test.ts
@@ -94,7 +94,16 @@ describe.each([
   
     expect(openApiObject).toMatchSnapshot()
   })
-  
+
+  it('should serialize dates', () => {
+    const schema = z.date()
+    const openApiObject = zodToOpenAPI(schema)
+
+    expect(openApiObject).toEqual({
+      type: 'string',
+    })
+  });
+
   it('should serialize objects', () => {
     const schema = z.object({
       prop1: z.string(),

--- a/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
+++ b/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
@@ -51,6 +51,10 @@ export function zodToOpenAPI(
     }
   }
 
+  if (is(zodType, z.ZodDate)) {
+    object.type = 'string'
+  }
+
   if (is(zodType, z.ZodPassword)) {
     const { checks } = zodType._def
     const regex = zodType.buildFullRegExp()


### PR DESCRIPTION
This PR aims to mark the `ZodDate` type as `string` in the OpenAPI schema.

### Fixes
- #125
- #99

### What was done
In the `zod-to-openapi.ts` I have adde a check that will detect if the source is `ZodDate`, if it is the `object.type` will be set to `string`.

Additionally a test was added in the `zod-to-openapi.test.ts` to reflect this case.

> No breaking changes were added.