### PR TITLE
effects and required

### DIFF
--- a/packages/nestjs-zod/package.json
+++ b/packages/nestjs-zod/package.json
@@ -36,6 +36,7 @@
     "dev": "vite",
     "build": "rollup -c",
     "test": "TZ=UTC jest",
+    "test:debug": "TZ=UTC node --inspect ./node_modules/jest/bin/jest.js --runInBand",
     "lint": "eslint --ext .ts,.tsx src",
     "lint:fix": "eslint --ext .ts,.tsx src --fix"
   },

--- a/packages/nestjs-zod/src/openapi/zod-to-openapi.test.ts
+++ b/packages/nestjs-zod/src/openapi/zod-to-openapi.test.ts
@@ -278,3 +278,162 @@ describe('special types', () => {
     });
   })
 });
+
+describe('effects and required', () => {
+  test('effects and non optional schema properties are required', () => {
+    const z = nestjsZod
+    const schema = z.object({
+      name: z.string(),
+      document: z.preprocess(
+        (value) => value,
+        z.object({
+          kind: z.string(),
+          number: z.number(),
+        }),
+      ),
+    });
+    const openApiObject = zodToOpenAPI(schema);
+    expect(openApiObject).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        document: {
+          type: 'object',
+          properties: {
+            kind: {
+              type: 'string',
+            },
+            number: {
+              type: 'number',
+            },
+          },
+          required: ['kind', 'number'],
+        },
+      },
+      required: ['name', 'document'],
+    });
+  });
+
+  test('effects and optional schema properties are not required', () => {
+    const z = nestjsZod;
+    const schema = z.object({
+      name: z.string(),
+      document: z.preprocess(
+        (value) => value,
+        z
+          .object({
+            kind: z.string(),
+            number: z.number(),
+          })
+          .optional(),
+      ),
+    });
+    const openApiObject = zodToOpenAPI(schema);
+    expect(openApiObject).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        document: {
+          type: 'object',
+          properties: {
+            kind: {
+              type: 'string',
+            },
+            number: {
+              type: 'number',
+            },
+          },
+          required: ['kind', 'number'],
+        },
+      },
+      required: ['name'],
+    });
+  });
+
+  test('effects and schema properties with default are not required', () => {
+    const z = nestjsZod;
+    const schema = z.object({
+      name: z.string(),
+      document: z.preprocess(
+        (value) => value,
+        z
+          .object({
+            kind: z.string(),
+            number: z.number(),
+          })
+          .default({ kind: '', number: 1 }),
+      ),
+    });
+    const openApiObject = zodToOpenAPI(schema);
+    expect(openApiObject).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        document: {
+          type: 'object',
+          properties: {
+            kind: {
+              type: 'string',
+            },
+            number: {
+              type: 'number',
+            },
+          },
+          required: ['kind', 'number'],
+          default: {
+            kind: '',
+            number: 1,
+          },
+        },
+      },
+      required: ['name'],
+    });
+  });
+
+  test('effects and nullish schema properties with default are not required', () => {
+    const z = nestjsZod;
+    const schema = z.object({
+      name: z.string(),
+      document: z.preprocess(
+        (value) => value,
+        z
+          .object({
+            kind: z.string(),
+            number: z.number(),
+          })
+          .nullish()
+          .default(null),
+      ),
+    });
+    const openApiObject = zodToOpenAPI(schema);
+    expect(openApiObject).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        document: {
+          type: 'object',
+          properties: {
+            kind: {
+              type: 'string',
+            },
+            number: {
+              type: 'number',
+            },
+          },
+          required: ['kind', 'number'],
+          nullable: true,
+          default: null,
+        },
+      },
+      required: ['name'],
+    });
+  });
+});

--- a/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
+++ b/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
@@ -207,8 +207,17 @@ export function zodToOpenAPI(
 
     for (const [key, schema] of Object.entries<z.ZodTypeAny>(shape())) {
       object.properties[key] = zodToOpenAPI(schema, visited)
-      const optionalTypes = [z.ZodOptional.name, z.ZodDefault.name]
-      const isOptional = optionalTypes.includes(schema.constructor.name)
+      let isOptional = false
+      const walk = (schema: z.ZodTypeAny) => {
+        if (is(schema, z.ZodEffects)) {
+          walk(schema._def.schema)
+        } else if (is(schema, z.ZodOptional)) {
+          isOptional = true
+        } else if (is(schema, z.ZodDefault)) {
+          isOptional = true
+        }
+      }
+      walk(schema)
       if (!isOptional) object.required.push(key)
     }
 

--- a/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
+++ b/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
@@ -211,9 +211,7 @@ export function zodToOpenAPI(
       const walk = (schema: z.ZodTypeAny) => {
         if (is(schema, z.ZodEffects)) {
           walk(schema._def.schema)
-        } else if (is(schema, z.ZodOptional)) {
-          isOptional = true
-        } else if (is(schema, z.ZodDefault)) {
+        } else if (is(schema, z.ZodOptional) || is(schema, z.ZodDefault)) {
           isOptional = true
         }
       }


### PR DESCRIPTION
This fixes an issue where properties that are instances of `ZodEffects`, but downstream are marked either optional or have a default value were still being marked as required in the OpenAPI doc.