### PR TITLE
feat: make z.date() generate date string type on openapi

### DIFF
--- a/packages/nestjs-zod/src/openapi/__snapshots__/zod-to-openapi.test.ts.snap
+++ b/packages/nestjs-zod/src/openapi/__snapshots__/zod-to-openapi.test.ts.snap
@@ -172,6 +172,10 @@ exports[`zodToOpenAPI (using @nest-zod/z) should serialize a complex schema 1`] 
         },
       ],
     },
+    "zodDate": {
+      "format": "date-time",
+      "type": "string",
+    },
     "zodDateString": {
       "format": "date-time",
       "type": "string",
@@ -192,6 +196,7 @@ exports[`zodToOpenAPI (using @nest-zod/z) should serialize a complex schema 1`] 
     "record",
     "recordWithKeys",
     "zodDateString",
+    "zodDate",
   ],
   "type": "object",
 }
@@ -426,6 +431,10 @@ exports[`zodToOpenAPI (using zod) should serialize a complex schema 1`] = `
         },
       ],
     },
+    "zodDate": {
+      "format": "date-time",
+      "type": "string",
+    },
     "zodDateString": {
       "format": "date-time",
       "type": "string",
@@ -446,6 +455,7 @@ exports[`zodToOpenAPI (using zod) should serialize a complex schema 1`] = `
     "record",
     "recordWithKeys",
     "zodDateString",
+    "zodDate",
   ],
   "type": "object",
 }

--- a/packages/nestjs-zod/src/openapi/zod-to-openapi.test.ts
+++ b/packages/nestjs-zod/src/openapi/zod-to-openapi.test.ts
@@ -1,6 +1,5 @@
-import { ZodTypeAny } from 'zod';
-import { z as actualZod } from '@nest-zod/z'
-import { z as nestjsZod } from '@nest-zod/z'
+import { z as actualZod, z as nestjsZod } from '@nest-zod/z'
+import { ZodTypeAny } from 'zod'
 import { zodToOpenAPI } from './zod-to-openapi'
 
 describe.each([
@@ -34,8 +33,9 @@ describe.each([
     record: z.record(z.number()),
     recordWithKeys: z.record(z.number(), z.string()),
     zodDateString: z.string().datetime(),
+    zodDate: z.date(),
   })
-  
+
   const intersectedObjectsSchema = z.intersection(
     z.object({
       one: z.number(),
@@ -44,12 +44,12 @@ describe.each([
       two: z.number(),
     })
   )
-  
+
   const intersectedUnionsSchema = z.intersection(
     z.union([z.literal('123'), z.number()]),
     z.union([z.boolean(), z.array(z.string())])
   )
-  
+
   const overrideIntersectionSchema = z.intersection(
     z.object({
       one: z.number(),
@@ -58,7 +58,7 @@ describe.each([
       one: z.string(),
     })
   )
-  
+
   const transformedSchema = z
     .object({
       seconds: z.number(),
@@ -68,40 +68,40 @@ describe.each([
       minutes: value.seconds / 60,
       hours: value.seconds / 3600,
     }))
-  
+
   const lazySchema = z.lazy(() => z.string())
-  
+
   it('should serialize a complex schema', () => {
     const openApiObject = zodToOpenAPI(complexTestSchema)
-  
+
     expect(openApiObject).toMatchSnapshot()
   })
-  
+
   it('should serialize an intersection of objects', () => {
     const openApiObject = zodToOpenAPI(intersectedObjectsSchema)
-  
+
     expect(openApiObject).toMatchSnapshot()
   })
-  
+
   it('should serialize an intersection of unions', () => {
     const openApiObject = zodToOpenAPI(intersectedUnionsSchema)
-  
+
     expect(openApiObject).toMatchSnapshot()
   })
-  
+
   it('should serialize an intersection with overrided fields', () => {
     const openApiObject = zodToOpenAPI(overrideIntersectionSchema)
-  
+
     expect(openApiObject).toMatchSnapshot()
   })
-  
+
   it('should serialize objects', () => {
     const schema = z.object({
       prop1: z.string(),
       prop2: z.string().optional(),
     })
     const openApiObject = zodToOpenAPI(schema)
-  
+
     expect(openApiObject).toEqual({
       type: 'object',
       required: ['prop1'],
@@ -115,7 +115,7 @@ describe.each([
       },
     })
   })
-  
+
   it('should serialize partial objects', () => {
     const schema = z
       .object({
@@ -124,7 +124,7 @@ describe.each([
       })
       .partial()
     const openApiObject = zodToOpenAPI(schema)
-  
+
     expect(openApiObject).toEqual({
       type: 'object',
       properties: {
@@ -137,54 +137,54 @@ describe.each([
       },
     })
   })
-  
+
   it('should serialize nullable types', () => {
     const schema = z.string().nullable()
     const openApiObject = zodToOpenAPI(schema)
-  
+
     expect(openApiObject).toEqual({ type: 'string', nullable: true })
   })
-  
+
   it('should serialize optional types', () => {
     const schema = z.string().optional()
     const openApiObject = zodToOpenAPI(schema)
-  
+
     expect(openApiObject).toEqual({ type: 'string' })
   })
-  
+
   it('should serialize types with default value', () => {
     const schema = z.string().default('abitia')
     const openApiObject = zodToOpenAPI(schema)
-  
+
     expect(openApiObject).toEqual({ type: 'string', default: 'abitia' })
   })
-  
+
   it('should serialize enums', () => {
     const schema = z.enum(['adama', 'kota'])
     const openApiObject = zodToOpenAPI(schema)
-  
+
     expect(openApiObject).toEqual({
       type: 'string',
       enum: ['adama', 'kota'],
     })
   })
-  
+
   it('should serialize native enums', () => {
     enum NativeEnum {
       ADAMA = 'adama',
       KOTA = 'kota',
     }
-  
+
     const schema = z.nativeEnum(NativeEnum)
     const openApiObject = zodToOpenAPI(schema)
-  
+
     expect(openApiObject).toEqual({
       'type': 'string',
       'enum': ['adama', 'kota'],
       'x-enumNames': ['ADAMA', 'KOTA'],
     })
   })
-  
+
   describe('scalar types', () => {
     const testCases: [ZodTypeAny, string, string?][] = [
       // [zod type, expected open api type, expected format]
@@ -195,12 +195,12 @@ describe.each([
       // [z.null(), 'null'], <- Needs OpenApi 3.1 to be represented correctly
       // [z.undefined(), 'undefined'], <- TBD, probably the property should be removed from schema
     ]
-  
+
     for (const [zodType, expectedType, expectedFormat] of testCases) {
       // eslint-disable-next-line no-loop-func
       it(expectedType, () => {
         const openApiObject = zodToOpenAPI(zodType)
-  
+
         expect(openApiObject).toEqual({
           type: expectedType,
           format: expectedFormat ?? undefined,
@@ -208,10 +208,10 @@ describe.each([
       })
     }
   })
-  
+
   it('should serialize transformed schema', () => {
     const openApiObject = zodToOpenAPI(transformedSchema)
-  
+
     expect(openApiObject).toEqual({
       type: 'object',
       required: ['seconds'],
@@ -222,16 +222,15 @@ describe.each([
       },
     })
   })
-  
+
   it('should serialize lazy schema', () => {
     const openApiObject = zodToOpenAPI(lazySchema)
-  
+
     expect(openApiObject).toEqual({
       type: 'string',
     })
   })
-});
-
+})
 
 describe('special types', () => {
   const specialSchema = nestjsZod.object({
@@ -244,7 +243,7 @@ describe('special types', () => {
       .atLeastOne('uppercase')
       .min(8)
       .max(100),
-  });
+  })
 
   test('works for special types', () => {
     const openApiObject = zodToOpenAPI(specialSchema)
@@ -254,27 +253,27 @@ describe('special types', () => {
         dateString: {
           description: 'My date string',
           format: 'date-time',
-          type: 'string'
+          type: 'string',
         },
         password: {
           format: 'password',
           pattern: '^.*$',
-          type: 'string'
+          type: 'string',
         },
         passwordComplex: {
           format: 'password',
           maxLength: 100,
           minLength: 8,
           pattern: '^(?:(?=.*\\d)(?=.*[A-Z]).*)$',
-          type: 'string'
+          type: 'string',
         },
         zodDateString: {
           format: 'date-time',
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       required: ['dateString', 'zodDateString', 'password', 'passwordComplex'],
-      type: 'object'
-    });
+      type: 'object',
+    })
   })
-});
+})

--- a/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
+++ b/packages/nestjs-zod/src/openapi/zod-to-openapi.ts
@@ -1,6 +1,6 @@
+import { z } from '@nest-zod/z'
 import { Type } from '@nestjs/common'
 import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface'
-import { z } from '@nest-zod/z'
 import deepmerge from 'deepmerge'
 
 interface ExtendedSchemaObject extends SchemaObject {
@@ -99,6 +99,11 @@ export function zodToOpenAPI(
         object.format = check.value
       }
     }
+  }
+
+  if (is(zodType, z.ZodDate)) {
+    object.type = 'string'
+    object.format = 'date-time'
   }
 
   if (is(zodType, z.ZodBigInt)) {
@@ -230,9 +235,9 @@ export function zodToOpenAPI(
       zodToOpenAPI(right, visited),
       {
         arrayMerge: (target, source) => {
-          const mergedSet = new Set([...target, ...source]);
-          return Array.from(mergedSet);
-        }
+          const mergedSet = new Set([...target, ...source])
+          return Array.from(mergedSet)
+        },
       }
     )
     Object.assign(object, merged)


### PR DESCRIPTION
Thank you so much for this great project.

A few day ago i started to use `orval` to generate axios and react query based openapi. I've already used this `nestjs-zod`. I noticed that it started to generate some `unknow` type and discovered that `nest-zod` was generating `Date` as `{}`. 

Follow this PR, hope you accept well.