### PR TITLE
feat(nestjs-zod/dto): inherit from the child class

### DIFF
--- a/packages/nestjs-zod/src/dto.ts
+++ b/packages/nestjs-zod/src/dto.ts
@@ -7,9 +7,10 @@ export interface ZodDto<
   TInput = TOutput
 > {
   new (): TOutput
+  new (values: unknown): TOutput
   isZodDto: true
   schema: ZodSchema<TOutput, TDef, TInput>
-  create(input: unknown): TOutput
+  create<T extends this>(this: T, input: unknown): InstanceType<typeof this>
 }
 
 export function createZodDto<
@@ -22,7 +23,17 @@ export function createZodDto<
     public static schema = schema
 
     public static create(input: unknown) {
-      return Object.assign(Object.create(this.prototype), this.schema.parse(input))
+      return Object.assign(
+        Object.create(this.prototype),
+        this.schema.parse(input)
+      )
+    }
+
+    constructor(values?: unknown) {
+      if (typeof values !== 'undefined') {
+        // eslint-disable-next-line no-constructor-return
+        return new.target.create(values)
+      }
     }
   }
 


### PR DESCRIPTION
Hi @BenLorantfy, would it be okay to make the factory return an instance of the class it creates? I have some methods in the dtos that I'd like to use without jumping through hoops.

```ts
class User extends createZodDto(z.object({
  name: z.string(),
})) {
  greet() {
    console.log(`Hi, my name is ${this.name}`)
  }
}

const user = User.create({ name: 'Josh' }) // the type of `user` is `User` (includes `greet`) but is actually a plain object containing only the value it is created with
```

Thanks!
