### PR TITLE
More misc fixes

### DIFF
--- a/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
+++ b/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
@@ -1296,8 +1296,6 @@ test('does not touch refs for schemas that are not from a zod dto', async () => 
     expect(JSON.stringify(doc)).not.toContain(PREFIX);
 })
 
-// TODO: write test for mutually recursive named schemas where one schmea is additionally directly recursive with itself
-
 test.skip('names output schema Book instead of BookDto if only using as output', async () => {        
     class BookDto extends createZodDto(z.object({
         title: z.string(),

--- a/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
+++ b/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
@@ -413,6 +413,22 @@ describe('direct array schemas', () => {
     });
 });
 
+test('throws error if using array DTO for parameters', async () => {
+    class BookListDto extends createZodDto(z.array(z.object({ title: z.string() }))) { }
+
+    @Controller()
+    class BookController {
+        constructor() { }
+
+        @Post()
+        createBooks(@Query() books: BookListDto) {
+            return [];
+        }
+    }
+
+    await expect(getSwaggerDoc(BookController)).rejects.toThrow('[cleanupOpenApiDoc] Array DTOs are not supported for query or url parameters')
+})
+
 test('named schemas', async () => {        
     class BookDto extends createZodDto(z.object({
         title: z.string(),
@@ -1094,6 +1110,104 @@ test('mutually recursive named schemas', async () => {
     expect(JSON.stringify(doc)).not.toContain(PREFIX);
 });
 
+test('recursive unnamed sub-schemas', async () => {
+    const Dog = z.object({
+        name: z.string(),
+        // In this case where zod needs to reference a schema that has no
+        // explicit ID, it generates a def anyway and names it
+        // `__schema{number}`.  This causes us problems, because __schema0 is
+        // not a unique def key name, so it will clash if consumers use
+        // recursive schemas multiple times.  To fix this, `cleanupOpenApiDoc`
+        // should prefix `__schema0` with the root schema name 
+        // (e.g. `DogPersonDto__schema0` or `CatPersonDto__schema0` instead of just `__schema0`)
+        get mother() {
+            return Dog;
+        }
+    })
+
+    const DogPerson = z.object({
+        name: z.string(),
+        dog: Dog,
+    })
+
+    class DogPersonDto extends createZodDto(DogPerson) { }
+
+    const Cat = z.object({
+        name: z.string(),
+        litterBoxFull: z.boolean(),
+        get mother() {
+            return Cat;
+        }
+    })
+
+    const CatPerson = z.object({
+        name: z.string(),
+        cat: Cat,
+    });
+
+    class CatPersonDto extends createZodDto(CatPerson) { }
+
+    @Controller()
+    class MyController {
+        constructor() { }
+
+        @Get('/dog-person')
+        @ApiResponse({
+            type: DogPersonDto,
+        })
+        getDogPerson() {
+            return {};
+        }
+
+        @Get('/cat-person')
+        @ApiResponse({
+            type: CatPersonDto,
+        })
+        getCatPerson() {
+            return {};
+        }
+    }
+
+    const doc = await getSwaggerDoc(MyController);
+    expect(doc.components?.schemas).toEqual({
+        CatPersonDto: expect.objectContaining({
+            type: 'object',
+            properties: expect.objectContaining({
+                cat: {
+                    '$ref': '#/components/schemas/CatPersonDto__schema0'
+                }
+            }) 
+        }),
+        CatPersonDto__schema0: expect.objectContaining({
+            type: 'object',
+            properties: expect.objectContaining({
+                mother: {
+                    '$ref': '#/components/schemas/CatPersonDto__schema0'
+                }
+            })
+        }),
+        DogPersonDto: expect.objectContaining({
+            type: 'object',
+            properties: expect.objectContaining({
+                dog: {
+                    '$ref': '#/components/schemas/DogPersonDto__schema0'
+                }
+            }) 
+        }),
+        DogPersonDto__schema0: expect.objectContaining({
+            type: 'object',
+            properties: expect.objectContaining({
+                mother: {
+                    '$ref': '#/components/schemas/DogPersonDto__schema0'
+                }
+            })
+        })
+    });
+    expect(get(doc, 'paths./cat-person.get.responses.default.content.application/json.schema.$ref')).toEqual('#/components/schemas/CatPersonDto');
+    expect(get(doc, 'paths./dog-person.get.responses.default.content.application/json.schema.$ref')).toEqual('#/components/schemas/DogPersonDto');
+    expect(JSON.stringify(doc)).not.toContain(PREFIX);
+})
+
 test('throws an error if trying to use recursive schemas in parameters', async () => {
     const QueryParams = z.object({
         name: z.string(),
@@ -1181,8 +1295,6 @@ test('does not touch refs for schemas that are not from a zod dto', async () => 
     expect(get(doc, 'paths./.post.parameters[0].schema.items.$ref')).toEqual('#/$defs/MyFilter');
     expect(JSON.stringify(doc)).not.toContain(PREFIX);
 })
-
-// TODO: write tests for recursive schemas
 
 // TODO: write test for mutually recursive named schemas where one schmea is additionally directly recursive with itself
 

--- a/packages/nestjs-zod/src/response.ts
+++ b/packages/nestjs-zod/src/response.ts
@@ -1,4 +1,4 @@
-import { applyDecorators } from '@nestjs/common';
+import { applyDecorators, HttpCode } from '@nestjs/common';
 import { ApiResponse } from '@nestjs/swagger';
 import { ZodSerializerDto } from './serializer';
 import { ZodDto } from './dto';
@@ -7,20 +7,24 @@ import { input } from 'zod/v4/core';
 import { RequiredBy, UnknownSchema } from './types';
 
 /**
- * `@ZodResponse` can be used to set the response DTO for a method
+ * `@ZodResponse` can be used to set the response information for a method.
+ * This is the recommended way to handle responses, since it applies a few
+ * related decorators at once to keep them in sync:
  *
- * It actually does a few things:
- * 1. Serializes the return value of the method using `@ZodSerializerDto`.  This
+ * 1. Uses `@ZodSerializerDto` to serialize the return value of the method.  This
  *    means the return value of the method will be parsed by the DTO's schema.
- * 2. Sets the response DTO for the method using `@ApiResponse`.  This means the
- *    OpenAPI documentation will be updated to reflect the DTO's schema.  Note
- *    that ZodResponse automatically uses the output version of the DTO, so
+ * 2. Uses `@ApiResponse` to set the response DTO for the method.  This means
+ *    the OpenAPI documentation will be updated to reflect the DTO's schema.
+ *    Note that ZodResponse automatically uses the output version of the DTO, so
  *    there is no need to use DTO.Output.
- * 3. Throws a typescript error if the return value of the method does not match
- *    the DTO's input schema.
+ * 3. Uses `@HttpCode` to set the HTTP status code for the response if `status`
+ *    is provided
+ * 4. Lastly, it also throws a typescript error if the return value of the
+ *    method does not match the DTO's input schema.
+ * 
+ * `@ZodResponse` is powerful because it keeps the run-time, compile-time, and
+ * docs-time response representations in sync
  *
- * It's recommended to use this decorator because it will keep the
- * serialization, OpenAPI documentation, and compile-time type checking in sync
  * 
  * @example
  * ```ts
@@ -39,24 +43,26 @@ import { RequiredBy, UnknownSchema } from './types';
  *   return [{ id: '1' }, { id: '2' }];
  * }
  */
-export function ZodResponse<TSchema extends UnknownSchema>({ status, description, type }: { status: number, description: string, type: ZodDto<TSchema> & { io: "input" } }): (target: object, propertyKey?: string | symbol, descriptor?: Pick<TypedPropertyDescriptor<(...args: any[]) => input<TSchema>|Promise<input<TSchema>>>, 'value'>) => void
-export function ZodResponse<TSchema extends RequiredBy<UnknownSchema, 'array'>>({ status, description, type }: { status: number, description: string, type: [ZodDto<TSchema> & { io: "input" }] }): (target: object, propertyKey?: string | symbol, descriptor?: Pick<TypedPropertyDescriptor<(...args: any[]) => Array<input<TSchema>>|Promise<Array<input<TSchema>>>>, 'value'>) => void
-export function ZodResponse<TSchema extends UnknownSchema>({ status, description, type }: { status: number, description: string, type: (ZodDto<TSchema> & { io: "input" })|[ZodDto<TSchema> & { io: "input" }] }): (target: object, propertyKey?: string | symbol, descriptor?: Pick<TypedPropertyDescriptor<(...args: any[]) => Array<input<TSchema>>|Promise<Array<input<TSchema>>>|input<TSchema>|Promise<input<TSchema>>>, 'value'>) => void {
+export function ZodResponse<TSchema extends UnknownSchema>({ status, description, type }: { status?: number, description?: string, type: ZodDto<TSchema> & { io: "input" } }): (target: object, propertyKey?: string | symbol, descriptor?: Pick<TypedPropertyDescriptor<(...args: any[]) => input<TSchema>|Promise<input<TSchema>>>, 'value'>) => void
+export function ZodResponse<TSchema extends RequiredBy<UnknownSchema, 'array'>>({ status, description, type }: { status?: number, description?: string, type: [ZodDto<TSchema> & { io: "input" }] }): (target: object, propertyKey?: string | symbol, descriptor?: Pick<TypedPropertyDescriptor<(...args: any[]) => Array<input<TSchema>>|Promise<Array<input<TSchema>>>>, 'value'>) => void
+export function ZodResponse<TSchema extends UnknownSchema>({ status, description, type }: { status?: number, description?: string, type: (ZodDto<TSchema> & { io: "input" })|[ZodDto<TSchema> & { io: "input" }] }): (target: object, propertyKey?: string | symbol, descriptor?: Pick<TypedPropertyDescriptor<(...args: any[]) => Array<input<TSchema>>|Promise<Array<input<TSchema>>>|input<TSchema>|Promise<input<TSchema>>>, 'value'>) => void {
   if (Array.isArray(type)) {
     assert(type[0].io === "input", 'ZodResponse automatically uses the output version of the DTO, there is no need to use DTO.Output');
 
-    return applyDecorators(
+    return applyDecorators(...[
+      ...(status ? [HttpCode(status)] : []),
       ZodSerializerDto(type),
       ApiResponse({ status, description, type: ['_zod' in type[0].schema ? type[0].Output : type[0]] }),
-    )
+    ])
 
   } else {
     assert(type.io === "input", 'ZodResponse automatically uses the output version of the DTO, there is no need to use DTO.Output');
 
-    return applyDecorators(
+    return applyDecorators(...[
+      ...(status ? [HttpCode(status)] : []),
       ZodSerializerDto(type),
       ApiResponse({ status, description, type: '_zod' in type.schema ? type.Output : type }),
-    )
+    ])
   }
 }
 

--- a/packages/nestjs-zod/src/utils.ts
+++ b/packages/nestjs-zod/src/utils.ts
@@ -1,9 +1,21 @@
 import { JSONSchema } from "zod/v4/core";
 
-export function fixAllRefs({ schema, rootSchemaName }: { schema: JSONSchema.BaseSchema, rootSchemaName?: string }) {
+export function fixAllRefs({ schema, defRenames, rootSchemaName }: { schema: JSONSchema.BaseSchema, defRenames?: Record<string, string>, rootSchemaName?: string }) {
     return walkJsonSchema(schema, (s) => {
         if (s.$ref) {
+          if (s.$ref.startsWith('#/$defs/')) {
+            const oldDefName = s.$ref.replace('#/$defs/', '');
+            const newDefName = defRenames?.[oldDefName];
+            if (newDefName) {
+              s.$ref = `#/$defs/${newDefName}`;
+            }
+          }
+
+
             s.$ref = s.$ref.replace('#/$defs/', '#/components/schemas/');
+
+
+            
             if (s.$ref === '#') {
               if (!rootSchemaName) {
                 throw new Error('[fixAllRefs] rootSchemaName is required when fixing a ref to #');


### PR DESCRIPTION
- Fixes error that occurred when trying to use a sub-schema that references itself
- Adds error message when trying to use array schema for query or url parameters
- Makes `status` and `description` optional in `@ZodResponse`
- Make `@ZodResponse` apply `@HttpCode` if `status` is provided