### PR TITLE
allow Zod unrepresentable schemas without throwing error

### DIFF
--- a/packages/nestjs-zod/src/dto.ts
+++ b/packages/nestjs-zod/src/dto.ts
@@ -187,7 +187,8 @@ function generateJsonSchema(schema: z3.ZodTypeAny | ($ZodType & { parse: (input:
         if (io === 'output' && 'id' in jsonSchema) {
             jsonSchema.id = `${jsonSchema.id}_Output`;
         }
-    } 
+    },
+    unrepresentable: 'any' 
   }) : zodV3ToOpenAPI(schema)
 
   const $defs = ('$defs' in generatedJsonSchema && generatedJsonSchema.$defs) ? generatedJsonSchema.$defs : undefined;


### PR DESCRIPTION
**nestjs-zod** should not forbid flexibility of **zod** and need to allow _unrepresentable_ schemas also 