### PR TITLE
Add AGENTS.md and pnpm build approval for cloud agent development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+This is a pnpm monorepo (`pnpm-workspace.yaml`) for the `nestjs-zod` library ecosystem. No databases, Docker, or external services are required — everything runs in-memory.
+
+### Build order (critical)
+`@nest-zod/z` must be built **before** `nestjs-zod` tests or builds, since `nestjs-zod` depends on it via `workspace:*`:
+1. `cd packages/z && pnpm build`
+2. `cd packages/nestjs-zod && pnpm test` / `pnpm build`
+
+### Key commands
+All commands are in each package's `package.json` scripts. The important ones:
+
+| Package | Test | Build | Lint |
+|---|---|---|---|
+| `packages/z` | `pnpm test` (Jest) | `pnpm build` (rollup) | — |
+| `packages/nestjs-zod` | `pnpm test` (Jest) | `pnpm build` (tsdown) | `pnpm lint` (ESLint), `pnpm format:check` (Prettier) |
+| `packages/example` | `pnpm test` (Jest) | `pnpm build` (nest build) | — |
+| `packages/example-dual-zods` | `pnpm test` (Jest) | `pnpm build` (nest build) | — |
+| `packages/example-esm` | — | `pnpm build` (nest build + SWC) | — |
+
+### Running the example app
+The example Star Wars app listens on port **3001** (not 3000). After building:
+```
+cd packages/example && pnpm build && node dist/main.js
+```
+Swagger UI is available at `http://localhost:3001/api`.
+
+### pnpm v10 build approval
+The root `package.json` includes `pnpm.onlyBuiltDependencies` to allow `@nestjs/core`, `@scarf/scarf`, `@swc/core`, and `esbuild` postinstall scripts. This avoids the interactive `pnpm approve-builds` prompt.
+
+### Playwright tests (optional)
+The example apps have Playwright-based Swagger tests (`pnpm run test:swagger`). These require `pnpm exec playwright install --with-deps` first.

--- a/package.json
+++ b/package.json
@@ -2,5 +2,13 @@
     "name": "nestjs-zod-monorepo",
     "description": "All the NestJS + Zod utilities you need",
     "version": "0.0.1",
-    "private": true
+    "private": true,
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "@nestjs/core",
+            "@scarf/scarf",
+            "@swc/core",
+            "esbuild"
+        ]
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the cloud agent development environment for the `nestjs-zod` monorepo.

### Changes
- **`AGENTS.md`**: Added cloud-specific development instructions covering build order, key commands, example app port, and pnpm v10 build approval.
- **`package.json`**: Added `pnpm.onlyBuiltDependencies` to allow `@nestjs/core`, `@scarf/scarf`, `@swc/core`, and `esbuild` postinstall scripts non-interactively (required for pnpm v10+).

### Verified

| Check | Status |
|---|---|
| `pnpm install` | ✅ |
| `packages/z` build | ✅ |
| `packages/z` tests (22 tests) | ✅ |
| `packages/nestjs-zod` tests (135 tests) | ✅ |
| `packages/nestjs-zod` build | ✅ |
| `packages/nestjs-zod` lint | ✅ |
| `packages/nestjs-zod` format:check | ✅ |
| `packages/example` build + tests | ✅ |
| `packages/example-dual-zods` build + tests | ✅ |
| `packages/example-esm` build | ✅ |
| Example app running + Swagger UI | ✅ |
| POST /api/people (create Yoda) | ✅ 201 |

### Demo

[demo_swagger_ui_create_person.mp4](https://cursor.com/agents/bc-5db233fe-9cda-4a37-9237-c7188ea6e172/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_swagger_ui_create_person.mp4)

[Swagger UI overview](https://cursor.com/agents/bc-5db233fe-9cda-4a37-9237-c7188ea6e172/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_ui_overview.webp)
[POST 201 response](https://cursor.com/agents/bc-5db233fe-9cda-4a37-9237-c7188ea6e172/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_post_201_response.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5db233fe-9cda-4a37-9237-c7188ea6e172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5db233fe-9cda-4a37-9237-c7188ea6e172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

