### PR TITLE
fix: convert propertyNames and exclusiveMinimum/Maximum for OpenAPI 3.0

### DIFF
--- a/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
+++ b/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
@@ -1863,9 +1863,6 @@ test('recursive unnamed sub-schema with record', async () => {
         },
         children: {
           type: 'object',
-          propertyNames: {
-            type: 'string',
-          },
           additionalProperties: {
             $ref: '#/components/schemas/DogPersonDto__schema0',
           },
@@ -2873,7 +2870,7 @@ describe('issue#350', () => {
       }
     }
 
-    const doc = await getSwaggerDoc(QueueController);
+    const doc = await getSwaggerDoc(QueueController, { version: '3.1' });
 
     expect(
       get(
@@ -2888,6 +2885,157 @@ describe('issue#350', () => {
       ),
     ).toEqual('#/components/schemas/QueueName');
     expect(JSON.stringify(doc)).not.toContain(PREFIX);
+  });
+});
+
+describe('openapi 3.0 schema compatibility', () => {
+  it('removes propertyNames from z.record() schemas for OpenAPI 3.0', async () => {
+    class RecordDto extends createZodDto(
+      z.object({
+        data: z.record(z.string(), z.number()),
+      }),
+    ) {}
+
+    @Controller()
+    class RecordController {
+      @Post()
+      create(@Body() body: RecordDto) {
+        return body;
+      }
+    }
+
+    const app = await createApp(RecordController);
+    const doc = cleanupOpenApiDoc(
+      SwaggerModule.createDocument(
+        app,
+        new DocumentBuilder().setOpenAPIVersion('3.0.0').build(),
+      ),
+    );
+
+    const dataSchema = get(doc, 'components.schemas.RecordDto.properties.data');
+    expect(dataSchema).not.toHaveProperty('propertyNames');
+    expect(dataSchema).toEqual({
+      type: 'object',
+      additionalProperties: { type: 'number' },
+    });
+    expect(JSON.stringify(doc)).not.toContain(PREFIX);
+  });
+
+  it('converts exclusiveMinimum from number to boolean for OpenAPI 3.0', async () => {
+    class BoundsDto extends createZodDto(
+      z.object({
+        exclusiveMin: z.number().gt(5),
+        exclusiveMax: z.number().lt(10),
+        inclusiveMin: z.number().gte(3),
+        inclusiveMax: z.number().lte(20),
+      }),
+    ) {}
+
+    @Controller()
+    class BoundsController {
+      @Post()
+      create(@Body() body: BoundsDto) {
+        return body;
+      }
+    }
+
+    const app = await createApp(BoundsController);
+    const doc = cleanupOpenApiDoc(
+      SwaggerModule.createDocument(
+        app,
+        new DocumentBuilder().setOpenAPIVersion('3.0.0').build(),
+      ),
+    );
+
+    const props = get(doc, 'components.schemas.BoundsDto.properties');
+
+    // gt(5) should become minimum: 5, exclusiveMinimum: true
+    expect(props.exclusiveMin).toEqual({
+      type: 'number',
+      minimum: 5,
+      exclusiveMinimum: true,
+    });
+
+    // lt(10) should become maximum: 10, exclusiveMaximum: true
+    expect(props.exclusiveMax).toEqual({
+      type: 'number',
+      maximum: 10,
+      exclusiveMaximum: true,
+    });
+
+    // gte(3) should become minimum: 3 (no exclusiveMinimum needed)
+    expect(props.inclusiveMin).toEqual({
+      type: 'number',
+      minimum: 3,
+    });
+
+    // lte(20) should become maximum: 20 (no exclusiveMaximum needed)
+    expect(props.inclusiveMax).toEqual({
+      type: 'number',
+      maximum: 20,
+    });
+
+    expect(JSON.stringify(doc)).not.toContain(PREFIX);
+  });
+
+  it('preserves propertyNames in OpenAPI 3.1', async () => {
+    class RecordDto extends createZodDto(
+      z.object({
+        data: z.record(z.string(), z.number()),
+      }),
+    ) {}
+
+    @Controller()
+    class RecordController {
+      @Post()
+      create(@Body() body: RecordDto) {
+        return body;
+      }
+    }
+
+    const app = await createApp(RecordController);
+    const doc = cleanupOpenApiDoc(
+      SwaggerModule.createDocument(
+        app,
+        new DocumentBuilder().setOpenAPIVersion('3.1.1').build(),
+      ),
+    );
+
+    const dataSchema = get(doc, 'components.schemas.RecordDto.properties.data');
+    expect(dataSchema).toHaveProperty('propertyNames');
+  });
+
+  it('preserves exclusiveMinimum as number in OpenAPI 3.1', async () => {
+    class BoundsDto extends createZodDto(
+      z.object({
+        value: z.number().gt(5),
+      }),
+    ) {}
+
+    @Controller()
+    class BoundsController {
+      @Post()
+      create(@Body() body: BoundsDto) {
+        return body;
+      }
+    }
+
+    const app = await createApp(BoundsController);
+    const doc = cleanupOpenApiDoc(
+      SwaggerModule.createDocument(
+        app,
+        new DocumentBuilder().setOpenAPIVersion('3.1.1').build(),
+      ),
+    );
+
+    const valueSchema = get(
+      doc,
+      'components.schemas.BoundsDto.properties.value',
+    );
+    expect(valueSchema).toEqual({
+      type: 'number',
+      exclusiveMinimum: 5,
+    });
   });
 });
 

--- a/packages/nestjs-zod/src/cleanupOpenApiDoc.ts
+++ b/packages/nestjs-zod/src/cleanupOpenApiDoc.ts
@@ -448,7 +448,7 @@ function cleanupSchema({
   //
   // This is the default behavior, since nestjs/swagger seems to generate
   // a 3.0 document by default
-  if ((hasNull || hasConst || hasId) && version === '3.0') {
+  if (version === '3.0') {
     // @ts-expect-error TODO: fix this
     newOpenapiSchema = convertToOpenApi3Point0(newOpenapiSchema);
   }
@@ -565,8 +565,7 @@ function fixParameter(
   if (
     version === '3.0' &&
     'schema' in parameter &&
-    parameter.schema &&
-    (hasConst || hasId || hasNull)
+    parameter.schema
   ) {
     // @ts-expect-error TODO: fix this
     parameter.schema = convertToOpenApi3Point0(parameter.schema);

--- a/packages/nestjs-zod/src/utils.ts
+++ b/packages/nestjs-zod/src/utils.ts
@@ -97,6 +97,22 @@ export function convertToOpenApi3Point0(schema: JSONSchema.BaseSchema) {
         delete s.const;
       }
 
+      // `propertyNames` is not valid in OpenAPI 3.0
+      if ('propertyNames' in s) {
+        delete s.propertyNames;
+      }
+
+      // In JSON Schema 2020-12, `exclusiveMinimum` and `exclusiveMaximum` are
+      // numbers.  In OpenAPI 3.0, they are booleans alongside `minimum`/`maximum`.
+      if (typeof s.exclusiveMinimum === 'number') {
+        s.minimum = s.exclusiveMinimum;
+        s.exclusiveMinimum = true;
+      }
+      if (typeof s.exclusiveMaximum === 'number') {
+        s.maximum = s.exclusiveMaximum;
+        s.exclusiveMaximum = true;
+      }
+
       return s;
     },
     {


### PR DESCRIPTION
## Summary

- Strip `propertyNames` from `z.record()` schemas when generating OpenAPI 3.0 (not a valid 3.0 keyword)
- Convert `exclusiveMinimum`/`exclusiveMaximum` from number (JSON Schema 2020-12) to boolean + `minimum`/`maximum` (OpenAPI 3.0 format)
- Ensure `convertToOpenApi3Point0` always runs for 3.0 documents, not only when schemas contain null/const/id markers

Fixes #366

## Test plan

- [x] Added tests for `propertyNames` removal in 3.0
- [x] Added tests for `exclusiveMinimum`/`exclusiveMaximum` conversion in 3.0
- [x] Added tests confirming 3.1 output is preserved unchanged
- [x] Updated existing tests whose expectations included `propertyNames` in 3.0 output
- [x] All 130 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)