### PR TITLE
fix: re-export isZodDto from main entrypoint

### DIFF
--- a/packages/nestjs-zod/src/index.test.ts
+++ b/packages/nestjs-zod/src/index.test.ts
@@ -1,0 +1,28 @@
+import { createZodDto, isZodDto, type ZodDto } from './index';
+import * as z4 from 'zod/v4';
+describe('main entrypoint exports', () => {
+  it('re-exports isZodDto (regression test for #431)', () => {
+    const UserSchema = z4.object({
+      username: z4.string(),
+    });
+
+    class UserDto extends createZodDto(UserSchema) {}
+
+    expect(isZodDto(UserDto)).toBe(true);
+    expect(isZodDto({})).toBe(false);
+  });
+
+  it('re-exports the ZodDto type (regression test for #431)', () => {
+    const UserSchema = z4.object({
+      username: z4.string(),
+    });
+
+    class UserDto extends createZodDto(UserSchema) {}
+
+    // If ZodDto were not exported from the main entrypoint, this would fail
+    // to type-check.
+    const dto: ZodDto<typeof UserSchema> = UserDto;
+
+    expect(isZodDto(dto)).toBe(true);
+  });
+});

--- a/packages/nestjs-zod/src/index.ts
+++ b/packages/nestjs-zod/src/index.ts
@@ -1,5 +1,5 @@
 export type { ZodDto } from './dto';
-export { createZodDto } from './dto';
+export { createZodDto, isZodDto } from './dto';
 export { ZodValidationException, ZodSerializationException } from './exception';
 export { createZodGuard, UseZodGuard, ZodGuard } from './guard';
 export { zodV3ToOpenAPI } from './zodV3ToOpenApi';


### PR DESCRIPTION
## Summary

Re-exports `isZodDto` alongside `createZodDto` from the main `nestjs-zod` entrypoint (`ZodDto` was already re-exported as a type).

Previously `isZodDto` was only available from the `nestjs-zod/dto` subpath, which fails to resolve under TypeScript's legacy `moduleResolution: "node"` (node10), a common default in NestJS projects using `module: "commonjs"` without an explicit `moduleResolution`.

## Change

```ts
// src/index.ts
- export { createZodDto } from './dto';
+ export { createZodDto, isZodDto } from './dto';
```

## Testing

- Added `src/index.test.ts` with regression tests verifying both `isZodDto` and the `ZodDto` type are importable from the main entrypoint.
- Full test suite passes.
- `tsc --noEmit` shows no new type errors (the pre-existing errors in `response.ts` are unrelated and present on `main` as well).
- `eslint` and `prettier --check` pass on the changed files.

Fixes #431