### PR TITLE
fix: expose dist chunks in exports map so declaration emit works under Bundler resolution

### DIFF
--- a/packages/nestjs-zod/package.json
+++ b/packages/nestjs-zod/package.json
@@ -23,6 +23,14 @@
         "types": "./dist/dto.d.cts",
         "default": "./dist/dto.cjs"
       }
+    },
+    "./dist/*.cjs": {
+      "types": "./dist/*.d.cts",
+      "require": "./dist/*.cjs"
+    },
+    "./dist/*.mjs": {
+      "types": "./dist/*.d.mts",
+      "import": "./dist/*.mjs"
     }
   },
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Fixes #449

## What

Adds two wildcard subpath entries to the `exports` map of the `nestjs-zod` package so the internal dist chunks (for example `dist/dto-D-BwC0n0.cjs`, where the `ZodDto` type lives) are reachable through a valid module specifier:

```json
"./dist/*.cjs": { "types": "./dist/*.d.cts", "require": "./dist/*.cjs" },
"./dist/*.mjs": { "types": "./dist/*.d.mts", "import": "./dist/*.mjs" }
```

## Why

With TypeScript 6 and its new default module resolution (`Bundler`), any project that compiles with `declaration: true` fails with TS2883 on every `createZodDto` class:

```
error TS2883: The inferred type of 'SuccessDto' cannot be named without a reference to 'ZodDto' from '../node_modules/nestjs-zod/dist/dto-D-BwC0n0.cjs'. This is likely not portable. A type annotation is necessary.
```

Declaration emit has to name the inferred base type `ZodDto<...>`. That type is declared in a hash-named chunk that the current `exports` map does not expose, so under resolution modes that honor the `exports` map there is no legal way to reference it and the emit fails. Full analysis is in #449.

## Verification

Applied this exact change as a `pnpm patch` in a NestJS project with around 340 `createZodDto` DTOs, compiled with TypeScript 6.0.3 and no explicit `moduleResolution`. All 340+ TS2883 errors disappear and the emitted declarations reference the type as `import("nestjs-zod/dist/dto-D-BwC0n0.cjs").t`. Runtime resolution is unaffected since this only adds subpaths and changes nothing about the existing `.` and `./dto` entries.

As mentioned in the issue, an AI coding assistant helped with bisecting compiler options and testing candidate fixes. Everything stated here was verified by running the compiler.

A longer-term improvement could be to have tsdown emit stable, non-chunked declaration files so consumers get `import("nestjs-zod").ZodDto` style references instead of hash-named chunk paths, but this change is enough to unblock declaration emit for consumers today.
