### PR TITLE
fix: remove propertyNames after nullable cleanup

### DIFF
--- a/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
+++ b/packages/nestjs-zod/src/__e2e_tests__/openapi.test.ts
@@ -3252,6 +3252,44 @@ describe('issue#366 - propertyNames and exclusiveMinimum/Maximum in openapi 3.0'
   );
 
   testMany(
+    'removes propertyNames from nullable record schemas for OpenAPI 3.0',
+    async ({ z }) => {
+      class NullableRecordDto extends createZodDto(
+        z.object({
+          transferInfo: z.record(z.string(), z.any()).nullish(),
+        }),
+      ) {}
+
+      @Controller()
+      class NullableRecordController {
+        @Post()
+        create(@Body() body: NullableRecordDto) {
+          return body;
+        }
+      }
+
+      const app = await createApp(NullableRecordController);
+      const doc = cleanupOpenApiDoc(
+        SwaggerModule.createDocument(
+          app,
+          new DocumentBuilder().setOpenAPIVersion('3.0.0').build(),
+        ),
+      );
+
+      const transferInfo = get(
+        doc,
+        'components.schemas.NullableRecordDto.properties.transferInfo',
+      );
+
+      expect(transferInfo).not.toHaveProperty('propertyNames');
+      expect(transferInfo).toHaveProperty('nullable', true);
+      expect(JSON.stringify(doc)).not.toContain(PREFIX);
+      expect(await getOpenApiErrors(doc, '3.0')).toHaveLength(0);
+    },
+    ['4.0.0', 'latest'],
+  );
+
+  testMany(
     'converts exclusiveMinimum/Maximum from number to boolean for OpenAPI 3.0',
     async ({ z }) => {
       class BoundsDto extends createZodDto(

--- a/packages/nestjs-zod/src/utils.ts
+++ b/packages/nestjs-zod/src/utils.ts
@@ -55,18 +55,12 @@ export function convertToOpenApi3Point0(schema: JSONSchema.BaseSchema) {
   return walkJsonSchema(
     schema,
     (s) => {
-      // `id` is not valid in OpenAPI 3.0.  Some generators, like
-      // `openapi-generator` fail if they come across unrecognized fields
-      if ('id' in s) {
-        delete s.id;
-      }
-
       if (s.anyOf) {
         const nullSchema = s.anyOf.findIndex(
           (subSchema) => subSchema.type === 'null',
         );
         if (nullSchema === -1) {
-          return s;
+          return cleanOpenApi3Point0Schema(s);
         }
 
         s.anyOf.splice(nullSchema, 1);
@@ -76,11 +70,15 @@ export function convertToOpenApi3Point0(schema: JSONSchema.BaseSchema) {
         if (anyOf.length === 1) {
           const sole = anyOf[0];
           if (sole.$ref && Object.keys(sole).length === 1) {
-            return { allOf: [sole], nullable: true, ...rest };
+            return cleanOpenApi3Point0Schema({
+              allOf: [sole],
+              nullable: true,
+              ...rest,
+            });
           }
 
           const enumValues = Array.isArray(sole.enum) ? sole.enum : undefined;
-          return {
+          return cleanOpenApi3Point0Schema({
             ...sole,
             ...rest,
             // We need to add `null` to the `enum` array if it exists and is not
@@ -89,43 +87,53 @@ export function convertToOpenApi3Point0(schema: JSONSchema.BaseSchema) {
             ...(enumValues &&
               !enumValues.includes(null) && { enum: [...enumValues, null] }),
             nullable: true,
-          };
+          });
         }
 
-        return {
+        return cleanOpenApi3Point0Schema({
           ...rest,
           anyOf,
           nullable: true,
-        };
+        });
       }
 
-      if (typeof s.const !== 'undefined') {
-        s.enum = [s.const];
-        delete s.const;
-      }
-
-      // `propertyNames` is not valid in OpenAPI 3.0
-      if ('propertyNames' in s) {
-        delete s.propertyNames;
-      }
-
-      // In JSON Schema 2020-12, `exclusiveMinimum` and `exclusiveMaximum` are
-      // numbers.  In OpenAPI 3.0, they are booleans alongside `minimum`/`maximum`.
-      if (typeof s.exclusiveMinimum === 'number') {
-        s.minimum = s.exclusiveMinimum;
-        s.exclusiveMinimum = true;
-      }
-      if (typeof s.exclusiveMaximum === 'number') {
-        s.maximum = s.exclusiveMaximum;
-        s.exclusiveMaximum = true;
-      }
-
-      return s;
+      return cleanOpenApi3Point0Schema(s);
     },
     {
       clone: true,
     },
   );
+}
+
+function cleanOpenApi3Point0Schema(s: JSONSchema.BaseSchema) {
+  // `id` is not valid in OpenAPI 3.0.  Some generators, like
+  // `openapi-generator` fail if they come across unrecognized fields
+  if ('id' in s) {
+    delete s.id;
+  }
+
+  if (typeof s.const !== 'undefined') {
+    s.enum = [s.const];
+    delete s.const;
+  }
+
+  // `propertyNames` is not valid in OpenAPI 3.0
+  if ('propertyNames' in s) {
+    delete s.propertyNames;
+  }
+
+  // In JSON Schema 2020-12, `exclusiveMinimum` and `exclusiveMaximum` are
+  // numbers.  In OpenAPI 3.0, they are booleans alongside `minimum`/`maximum`.
+  if (typeof s.exclusiveMinimum === 'number') {
+    s.minimum = s.exclusiveMinimum;
+    s.exclusiveMinimum = true;
+  }
+  if (typeof s.exclusiveMaximum === 'number') {
+    s.maximum = s.exclusiveMaximum;
+    s.exclusiveMaximum = true;
+  }
+
+  return s;
 }
 
 import deepmerge from 'deepmerge';


### PR DESCRIPTION
Summary:
- run OpenAPI 3.0 schema cleanup on schemas returned from nullable anyOf conversion
- remove invalid propertyNames from nullable record schemas after conversion to nullable: true
- add regression coverage for nullable record DTOs

Closes #448

Validation:
- .\node_modules\.bin\jest.CMD src/__e2e_tests__/openapi.test.ts -t "propertyNames" --runInBand --cacheDirectory "D:\grand-final prr\.cache\jest-nestjs-zod"
- .\node_modules\.bin\prettier.CMD --check src/utils.ts src/__e2e_tests__/openapi.test.ts
- $env:JITI_CACHE_DIR='D:\grand-final prr\.cache\jiti-nestjs-zod'; .\node_modules\.bin\eslint.CMD src/utils.ts src/__e2e_tests__/openapi.test.ts
- git diff --check

Note: dependency install populated node_modules but exited on pnpm ignored-builds policy; the focused tests, formatting, lint, and diff checks above all passed afterward.